### PR TITLE
Add 'patch' to apk add command (used by composer-patches)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --update --no-cache \
 	openssh \
 	rsync \
 	sudo \
+	patch \
 	&& rm -rf /var/cache/apk/*
 
 ARG GLIBC=2.25-r0


### PR DESCRIPTION
Add GNU patch to the agent image.

This is required by composer-patches, [the version included with busybox by default doesn't support some command line parameters and fails](https://github.com/cweagans/composer-patches/issues/159).