### PR TITLE
Release 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The following variables are derived from the respective Bitbucket Pipelines, Cir
 - `GIT_COMMIT_HASH` - git commit hash
 - `GIT_PR_NUMBER` - git pull request / merge request number
 - `GIT_REPO_SERVICE` - `github`, `bitbucket` or `gitlab` (makes sense mostly for CircleCI)
+- `BUILD_DIR` - The full path where the repository is cloned and where the job is run in the agent container
 
 `REMOTE_BUILD_DIR`
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ The user's name that should have access to the remote Docksal host. Defaults to 
 The default directory location on the remote server where the repositories should be cloned down to and built. 
 Defaults to `/home/ubuntu/builds`
 
+`REMOTE_CODEBASE_METHOD`
+
+Pick between `git` (default) and `rsync` for the codebase initialization method on the sandbox server.
+
+The codebase is initialized on the sandbox server by the `build-init` command.
+
+`git` - code is checkout on the sandbox server via git. Server must have access to checkout from the repo. 
+Any build settings and necessary code manipulations must happen on the sandbox server using `build-exec` commands.
+
+`rsync` - code is rsynced to the sandbox server from the build agent. You can perform necessary code adjustments in the 
+build agent after running `build-env` and before running `build-init`. The latter one will push the code to the sandbox 
+environment.
+
 `GITHUB_TOKEN` and `BITBUCKET_TOKEN`
 
 Used for access to post sandbox URLs via build status API as well as comments on pull requests.  

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,37 +6,29 @@ RUN apk add --update --no-cache \
 		git \
 		jq \
 		openssh \
+		py2-pip \
 		rsync \
 		sudo \
 		patch; \
 	rm -rf /var/cache/apk/*;
 
-ARG GLIBC=2.27-r0
-RUN \
-	# Install glibc libraries needed for docker-compose
-	apk update && apk add --no-cache openssl ca-certificates; \
-	curl -L https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub; \
-	curl -L -O https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC}/glibc-${GLIBC}.apk; \
-	apk add --no-cache glibc-${GLIBC}.apk && rm glibc-${GLIBC}.apk; \
-	ln -s /lib/libz.so.1 /usr/glibc-compat/lib/; \
-	ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib;
-
-ARG DOCKER_VERSION=17.09.0-ce
-ARG DOCKER_COMPOSE_VERSION=1.19.0
-RUN \
+ARG DOCKER_VERSION=18.06.0-ce
+ARG DOCKER_COMPOSE_VERSION=1.21.0
+RUN set -xe; \
 	# Install docker cli
 	curl -sSL -O "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz"; \
 	tar zxf docker-${DOCKER_VERSION}.tgz && mv docker/docker /usr/local/bin && rm -rf docker-${DOCKER_VERSION}*; \
-	# Install docker-compose cli
-	curl -sSL https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose; \
-	chmod +x /usr/local/bin/docker-compose; \
+	docker --version; \
+	# Install docker-compose cli (has to be installed via pip on Alpine)
+	pip install "docker-compose==${DOCKER_COMPOSE_VERSION}" >/dev/null; \
+	docker-compose --version; \
 	# Install minio client (mc)
 	curl -sSL https://dl.minio.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc; \
 	chmod +x /usr/local/bin/mc
 
 ENV AGENT_USER=agent
 ENV AGENT_HOME=/home/agent
-RUN \
+RUN set -xe; \
 	# Create a non-root user with access to sudo
 	adduser -h $AGENT_HOME -s /bin/bash -D $AGENT_USER; \
 	echo "$AGENT_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers;
@@ -44,14 +36,14 @@ RUN \
 # All further RUN commands will run as the "agent" user
 USER $AGENT_USER
 
-RUN \
+RUN set -xe; \
 	mkdir -p $AGENT_HOME/.ssh; \
 	mkdir -p $AGENT_HOME/build;
 
 COPY bin /usr/local/bin
 COPY config/.ssh/config $AGENT_HOME/.ssh/config
 # Fix permissions after COPY (could use COPY --chown, but will still need to run chmod)
-RUN \
+RUN set -xe; \
 	sudo chown $AGENT_USER:$AGENT_USER $AGENT_HOME/.ssh/config; \
 	sudo chmod 600 $AGENT_HOME/.ssh/config;
 

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -15,10 +15,9 @@ DOCKER_HOST_TUNNEL=localhost:2374
 GIT_USER_EMAIL=${GIT_USER_EMAIL:-ci@docksal.io}
 GIT_USER_NAME=${GIT_USER_NAME:-Docksal CI}
 
-# These are used to generate the sandbox domain name (branch.project.example.com)
+# These are used to generate the sandbox sub-domain (branch-project.example.com)
 # There is a limit of 63 characters for any part of the domain name.
-# With wildcard certs, DOMAIN_MODE="flat" should be used (branch-project.example.com) and the limit can be easily hit.
-# Keep these to 50 combined to leave space for sub-sub-domains (e.g. service-branch-project.example.com).
+# Limit these to 50 combined to leave some space for sub-sub-domains (e.g. service-branch-project.example.com).
 BRANCH_NAME_LENGTH_LIMIT=30
 REPO_NAME_LENGTH_LIMIT=20
 
@@ -162,19 +161,12 @@ sandbox_server_env ()
 	# Make sure domain name is lowercase
 	export DOCKSAL_DOMAIN="$(echo -n ${DOCKSAL_DOMAIN:-$DOCKSAL_HOST} | awk '{print tolower($0)}')"
 
-	# Set DOMAIN based on DOMAIN_MODE (either "multi" (default) or "flat")
-	# "DOMAIN_MODE=multi" (default) => branch.project.example.com
-	# "DOMAIN_MODE=flat" => branch-project.example.com
-	# Flat mode should be used in conjunction with a custom wildcard certificates, which can only cover a single level
-	# of sub-domains. I.e., a cert for "*.example.com", will only cover "sudomain.example.dom", but not
-	# "www.sudomain.example.com".
-	# NOTE: The length of any one label (subdomain) in the domain name is limited to between 1 and 63 octets (characters).
-	DOMAIN_MODE=${DOMAIN_MODE:=multi}
-	if [[ "$DOMAIN_MODE" == "flat" ]]; then
-		export DOMAIN="${BRANCH_NAME_SAFE}-${REPO_NAME_SAFE}.${DOCKSAL_DOMAIN}"
-	else
-		export DOMAIN="${BRANCH_NAME_SAFE}.${REPO_NAME_SAFE}.${DOCKSAL_DOMAIN}"
-	fi
+	# Use "flat" sub-domains (e.g. branch-project.example.com) and not multi-sub-domains (e.g. branch.project.example.com)
+	# This allows using a single wildcard cert for the entire sandbox server.
+	# Note: A wildcard cert for "*.example.com", will only cover "sub-domain.example.dom", but not
+	# "www.sub-domain.example.com".
+	# NOTE: The length of any one label (sub-domain) in the domain name is limited to 63 octets (characters).
+	export DOMAIN="${BRANCH_NAME_SAFE}-${REPO_NAME_SAFE}.${DOCKSAL_DOMAIN}"
 
 	# Initialize a tunnel to the Docker Engine on DOCKSAL_HOST
 	# Export local tunnel connection settings if it works

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -53,6 +53,8 @@ build_env ()
 		export GIT_COMMIT_HASH="$BITBUCKET_COMMIT"
 		# Bitbucket Pipelines does not work with PRs
 		#GIT_PR_NUMBER=?
+
+		export BUILD_DIR="$BITBUCKET_CLONE_DIR"
 	fi
 
 	# Support for CircleCI 2.0
@@ -76,6 +78,8 @@ build_env ()
 			# Cannot use $CIRCLE_PR_NUMBER as it's only available in forked PR builds
 			export GIT_PR_NUMBER=${CIRCLE_PULL_REQUEST##*/}
 		fi
+
+		export BUILD_DIR="$CIRCLE_WORKING_DIRECTORY"
 	fi
 
 	# Support for GitLab 9.0+
@@ -88,6 +92,8 @@ build_env ()
 		export GIT_BRANCH_NAME="$CI_COMMIT_REF_NAME"
 		export GIT_COMMIT_HASH="$CI_COMMIT_SHA"
 		export GIT_PR_NUMBER="$CI_MERGE_REQUEST_ID"
+
+		export BUILD_DIR="$CI_PROJECT_DIR"
 	fi
 
 	# For debug purposes these variables can be set manually.

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -11,10 +11,16 @@ set -e # Abort if anything fails
 # -------------------- Constants -------------------- #
 
 DEBUG=${DEBUG:-0}  # `DEBUG=1 build-env` to run with debugging turned ON
-BRANCH_NAME_LENGTH_LIMIT=35
 DOCKER_HOST_TUNNEL=localhost:2374
 GIT_USER_EMAIL=${GIT_USER_EMAIL:-ci@docksal.io}
 GIT_USER_NAME=${GIT_USER_NAME:-Docksal CI}
+
+# These are used to generate the sandbox domain name (branch.project.example.com)
+# There is a limit of 63 characters for any part of the domain name.
+# With wildcard certs, DOMAIN_MODE="flat" should be used (branch-project.example.com) and the limit can be easily hit.
+# Keep these to 50 combined to leave space for sub-sub-domains (e.g. service-branch-project.example.com).
+BRANCH_NAME_LENGTH_LIMIT=30
+REPO_NAME_LENGTH_LIMIT=20
 
 # -------------------- Functions -------------------- #
 
@@ -94,14 +100,14 @@ build_env ()
 
 	# URL safe branch name
 	BRANCH_NAME_SAFE="$(safe_string ${GIT_BRANCH_NAME})"
-	# Trim the branch name if longer than BRANCH_NAME_LENGTH_LIMIT and append the md5sum to keep the branch name unique
+	# Trim the branch name if longer than BRANCH_NAME_LENGTH_LIMIT and append the md5sum to keep the branch name unique.
 	if (( "${#BRANCH_NAME_SAFE}" > "$BRANCH_NAME_LENGTH_LIMIT" )); then
-		BRANCH_NAME_SAFE="$(echo -n "$BRANCH_NAME_SAFE" | cut -c1-30)-$(echo -n "$BRANCH_NAME_SAFE" | md5sum | cut -c1-4)"
+		BRANCH_NAME_SAFE="$(echo -n "$BRANCH_NAME_SAFE" | cut -c1-${BRANCH_NAME_LENGTH_LIMIT})-$(echo -n "$BRANCH_NAME_SAFE" | md5sum | cut -c1-3)"
 	fi
 	export BRANCH_NAME_SAFE
 
-	# Trim repo name to 30 characters. If someone has a repo name longer than that, then no mercy for them.
-	export REPO_NAME_SAFE="$(safe_string ${GIT_REPO_NAME:0:30})"
+	# Trim repo name if longer than REPO_NAME_LENGTH_LIMIT.
+	export REPO_NAME_SAFE="$(safe_string ${GIT_REPO_NAME:0:${REPO_NAME_LENGTH_LIMIT}})"
 	# Short version of GIT_COMMIT_HASH
 	export COMMIT_HASH_SHORT="${GIT_COMMIT_HASH:0:7}"
 }
@@ -155,8 +161,20 @@ sandbox_server_env ()
 	# This is useful when working with CDNs/ELBs/WAFs/etc (when DOCKSAL_DOMAIN is different from the DOCKSAL_HOST).
 	# Make sure domain name is lowercase
 	export DOCKSAL_DOMAIN="$(echo -n ${DOCKSAL_DOMAIN:-$DOCKSAL_HOST} | awk '{print tolower($0)}')"
-	# NOTE: The length of any one label in the domain name is limited to between 1 and 63 octets.
-	export DOMAIN="$BRANCH_NAME_SAFE.$REPO_NAME_SAFE.$DOCKSAL_DOMAIN"
+
+	# Set DOMAIN based on DOMAIN_MODE (either "multi" (default) or "flat")
+	# "DOMAIN_MODE=multi" (default) => branch.project.example.com
+	# "DOMAIN_MODE=flat" => branch-project.example.com
+	# Flat mode should be used in conjunction with a custom wildcard certificates, which can only cover a single level
+	# of sub-domains. I.e., a cert for "*.example.com", will only cover "sudomain.example.dom", but not
+	# "www.sudomain.example.com".
+	# NOTE: The length of any one label (subdomain) in the domain name is limited to between 1 and 63 octets (characters).
+	DOMAIN_MODE=${DOMAIN_MODE:=multi}
+	if [[ "$DOMAIN_MODE" == "flat" ]]; then
+		export DOMAIN="${BRANCH_NAME_SAFE}-${REPO_NAME_SAFE}.${DOCKSAL_DOMAIN}"
+	else
+		export DOMAIN="${BRANCH_NAME_SAFE}.${REPO_NAME_SAFE}.${DOCKSAL_DOMAIN}"
+	fi
 
 	# Initialize a tunnel to the Docker Engine on DOCKSAL_HOST
 	# Export local tunnel connection settings if it works

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -25,6 +25,14 @@ echo-debug ()
 	if [[ "$DEBUG" != 0 ]]; then echo "$@"; fi
 }
 
+# Generates a domain name safe string (alphanumeric characters and hyphens).
+# Invalid characters are replaced with hyphens.
+# The resulting string is converted to lowercase, since browsers are doing this automatically.
+safe_string ()
+{
+	(sed -e 's/[^A-Za-z0-9]/-/g' | awk '{print tolower($0)}') <<< "$1"
+}
+
 # Initial build environment configuration
 build_env ()
 {
@@ -85,7 +93,7 @@ build_env ()
 	fi
 
 	# URL safe branch name
-	BRANCH_NAME_SAFE="$(echo -n "$GIT_BRANCH_NAME" | sed -e 's/[^A-Za-z0-9]/-/g' | awk '{print tolower($0)}')"
+	BRANCH_NAME_SAFE="$(safe_string ${GIT_BRANCH_NAME})"
 	# Trim the branch name if longer than BRANCH_NAME_LENGTH_LIMIT and append the md5sum to keep the branch name unique
 	if (( "${#BRANCH_NAME_SAFE}" > "$BRANCH_NAME_LENGTH_LIMIT" )); then
 		BRANCH_NAME_SAFE="$(echo -n "$BRANCH_NAME_SAFE" | cut -c1-30)-$(echo -n "$BRANCH_NAME_SAFE" | md5sum | cut -c1-4)"
@@ -93,7 +101,7 @@ build_env ()
 	export BRANCH_NAME_SAFE
 
 	# Trim repo name to 30 characters. If someone has a repo name longer than that, then no mercy for them.
-	export REPO_NAME_SAFE="${GIT_REPO_NAME:0:30}"
+	export REPO_NAME_SAFE="$(safe_string ${GIT_REPO_NAME:0:30})"
 	# Short version of GIT_COMMIT_HASH
 	export COMMIT_HASH_SHORT="${GIT_COMMIT_HASH:0:7}"
 }
@@ -145,7 +153,8 @@ sandbox_server_env ()
 
 	# Allow setting DOCKSAL_DOMAIN individually from DOCKSAL_HOST. Default to DOCKSAL_HOST if not set.
 	# This is useful when working with CDNs/ELBs/WAFs/etc (when DOCKSAL_DOMAIN is different from the DOCKSAL_HOST).
-	export DOCKSAL_DOMAIN="${DOCKSAL_DOMAIN:-$DOCKSAL_HOST}"
+	# Make sure domain name is lowercase
+	export DOCKSAL_DOMAIN="$(echo -n ${DOCKSAL_DOMAIN:-$DOCKSAL_HOST} | awk '{print tolower($0)}')"
 	# NOTE: The length of any one label in the domain name is limited to between 1 and 63 octets.
 	export DOMAIN="$BRANCH_NAME_SAFE.$REPO_NAME_SAFE.$DOCKSAL_DOMAIN"
 

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -26,7 +26,7 @@ fi
 
 # Pass build secrets to sandbox
 # A "secret" is any environment variable that starts with "SECRET_"
-secrets="$(env | grep 'SECRET_')"
+secrets="$(env | grep 'SECRET_')" || true
 if [[ "$secrets" != "" ]]; then
 	echo "Passing build secrets to sandbox..."
 	build-exec "echo '$secrets' | tee -a .docksal/docksal-local.env >/dev/null"

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -2,6 +2,9 @@
 
 # This script sets up a sandbox environment for the build on the remote docker host.
 
+set -e # Abort if anything fails
+#set -x # Echo commands
+
 # Cleanup
 echo "Setting up remote build environment..."
 ssh docker-host "(cd $REMOTE_BUILD_DIR && fin rm -f 2>/dev/null) || true"
@@ -9,8 +12,13 @@ ssh docker-host "sudo rm -rf $REMOTE_BUILD_DIR 2>/dev/null; mkdir -p $REMOTE_BUI
 
 # Note: build-exec = ssh docker-host "cd $REMOTE_BUILD_DIR && ($@)"
 
-# Checkout sources
-build-exec "git clone --branch="$GIT_BRANCH_NAME" --depth 50 $GIT_REPO_URL . && git reset --hard $GIT_COMMIT_HASH && ls -la"
+# Checkout sources on the remote host
+#echo "Checking out codebase via git..."
+#build-exec "git clone --branch="$GIT_BRANCH_NAME" --depth 50 $GIT_REPO_URL . && git reset --hard $GIT_COMMIT_HASH && ls -la"
+
+# Rsync sources to the remote host
+echo "Syncing codebase via rsync..."
+rsync --delete -az ${BUILD_DIR}/ docker-host:${REMOTE_BUILD_DIR}
 
 # Configure sandbox settings
 echo "Configuring sandbox settings..."

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -12,13 +12,16 @@ ssh docker-host "sudo rm -rf $REMOTE_BUILD_DIR 2>/dev/null; mkdir -p $REMOTE_BUI
 
 # Note: build-exec = ssh docker-host "cd $REMOTE_BUILD_DIR && ($@)"
 
-# Checkout sources on the remote host
-#echo "Checking out codebase via git..."
-#build-exec "git clone --branch="$GIT_BRANCH_NAME" --depth 50 $GIT_REPO_URL . && git reset --hard $GIT_COMMIT_HASH && ls -la"
-
-# Rsync sources to the remote host
-echo "Syncing codebase via rsync..."
-rsync --delete -az ${BUILD_DIR}/ docker-host:${REMOTE_BUILD_DIR}
+# Remote codebase initialization method. Either 'git' (default) or 'rsync'
+if [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
+	# Rsync sources to the remote host
+	echo "Syncing codebase via rsync..."
+	rsync --delete -az ${BUILD_DIR}/ docker-host:${REMOTE_BUILD_DIR}
+else
+	# Checkout sources on the remote host
+	echo "Checking out codebase via git..."
+	build-exec "git clone --branch="$GIT_BRANCH_NAME" --depth 50 $GIT_REPO_URL . && git reset --hard $GIT_COMMIT_HASH && ls -la"
+fi
 
 # Configure sandbox settings
 echo "Configuring sandbox settings..."

--- a/base/bin/build-notify
+++ b/base/bin/build-notify
@@ -8,7 +8,7 @@
 DEBUG=${DEBUG:-0}  # `DEBUG=1 build-notify` to run with debugging turned ON
 
 export CONTEXT="ci/docksal"  # Context for notifications
-export URL="http://${DOMAIN}"  # Sandbox URL
+export URL="https://${DOMAIN}"  # Sandbox URL
 export STATUS_API=${STATUS_API:-1}  # Status API notifications enabled by default
 export PR_COMMENT=${PR_COMMENT:-0}  # PR comment notifications disabled by default
 
@@ -150,7 +150,7 @@ notify_success ()
 	# Post comment to a pull request on success only
 	# Note: pull request builds are not supported by Bitbucket Pipelines
 	if [[ "$CIRCLECI" != "" ]] && [[ "$PR_COMMENT" != 0 ]]; then
-		comment="$description: http://${DOMAIN}"
+		comment="$description: ${URL}"
 		[[ "${GIT_REPO_SERVICE}" == "github" ]] && github_pr_comment "$comment"
 		[[ "${GIT_REPO_SERVICE}" == "bitbucket" ]] && bitbucket_pr_comment "$comment"
 	fi


### PR DESCRIPTION
- Fixed a regression with SECRET variables. Fixes #27
- Use flat sub-domains (e.g. `branch-project.example.com`) for sandboxes
  - This allows using a single wildcard cert for the entire sandbox server
- Update docker and docker-compose versions
  - docker 18.06.0
  - docker-compose 1.21.0
  - Installing docker-compose via pip, since the old way (installing glibc libraries) now fails
- Use `https` for sandbox URLs in `build-notify`
- Added `BUILD_DIR` build variable (see docs)
- Added `REMOTE_CODEBASE_METHOD` variable (see docs)
  - Codebase can not be synced with `rsync` from agent to server in addition to the default `git` checkout method run on the server
