### PR TITLE
Release 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,14 @@ If using `DOCKSAL_HOST_IP`, the agent will use `nip.io` for dynamic wildcard dom
 
 `DOCKSAL_HOST_SSH_KEY`
 
-A base64 encoded private SSH key used to access the remote Docksal host.  
-See [Access remote hosts via SSH](https://confluence.atlassian.com/bitbucket/access-remote-hosts-via-ssh-847452940.html) 
-tutorial for details.
+A base64 encoded private SSH key, used to access the remote Docksal host.
 
 `CI_SSH_KEY`
 
-A secondary SSH key (base64 encoded as well), which can be used for deployments and other remote operations run directly 
-on the agent.
-E.g. cloning/pushing a repo, running commands over SSH on a remote deployment environment.
+A base64 encoded private SSH key, used by default for all hosts (set as `Host *` in `~/.ssh/config`).
+This key will be used to clone/push to repo, run commands over SSH on a remote deployment environment, etc.
 
+Note: `cat /path/to/<private_key_file> | base64` can be used to create a base64 encoded string from a private SSH key.
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,13 @@ jobs:
     docker:
       - image: docksal/ci-agent:php
     steps:
+      - run:
+          name: Configure agent environment
+          command: echo 'source build-env' >> $BASH_ENV
       - checkout
-      - run: source build-env && sandbox-init
+      - run:
+          name: Build sandbox
+          command: sandbox-init
 ```
 
 For a more advanced example see [config.yml](examples/.circleci/config.yml).

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The following variables are derived from the respective Bitbucket Pipelines, Cir
 - `GIT_COMMIT_HASH` - git commit hash
 - `GIT_PR_NUMBER` - git pull request / merge request number
 - `GIT_REPO_SERVICE` - `github`, `bitbucket` or `gitlab` (makes sense mostly for CircleCI)
+- `BUILD_ID` - The unique identifier for a build
 - `BUILD_DIR` - The full path where the repository is cloned and where the job is run in the agent container
 
 `REMOTE_BUILD_DIR`

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN apk add --update --no-cache \
 		bash \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.8
 
-RUN apk add --update --no-cache \
+RUN set -xe; \
+	apk add --update --no-cache \
 		bash \
 		curl \
 		git \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,7 +10,8 @@ RUN set -xe; \
 		py2-pip \
 		rsync \
 		sudo \
-		patch; \
+		patch \
+	; \
 	rm -rf /var/cache/apk/*;
 
 ARG DOCKER_VERSION=18.06.0-ce

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,6 +6,7 @@ RUN set -xe; \
 		curl \
 		git \
 		jq \
+		make \
 		openssh \
 		py2-pip \
 		rsync \

--- a/base/bin/build-acp
+++ b/base/bin/build-acp
@@ -60,7 +60,7 @@ echo "Files:"
 mc ls ${destination}
 
 # Post artifacts to Bitbucket build status API
-if [[ "${BITBUCKETCI}" != "" ]] && [[ "${BITBUCKET_TOKEN}" != "" ]]; then
+if [[ "${BITBUCKET_CI}" != "" ]] && [[ "${BITBUCKET_TOKEN}" != "" ]]; then
 	echo "Posting artifacts URL to Bitbucket..."
 
 	BUILD_STATUS_URL="${ARTIFACTS_URL}"

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -162,7 +162,7 @@ git_env ()
 		git config --global user.email "$GIT_USER_EMAIL"
 	fi
 	if [[ "$(git config --global user.name)" == "" ]] && [[ "$GIT_USER_NAME" != "" ]]; then
-		git config --global user.email "$GIT_USER_NAME"
+		git config --global user.name "$GIT_USER_NAME"
 	fi
 }
 

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -122,7 +122,9 @@ build_env ()
 	export COMMIT_HASH_SHORT="${GIT_COMMIT_HASH:0:7}"
 
 	# Sandbox settings
-	export REMOTE_BUILD_BASE=${REMOTE_BUILD_BASE:-/home/ubuntu/builds}
+	# Defaults for the sandbox user and builds directory: "build-agent" and "/home/build-agent/builds" respectively.
+	export DOCKSAL_HOST_USER="${DOCKSAL_HOST_USER:-build-agent}"
+	export REMOTE_BUILD_BASE=${REMOTE_BUILD_BASE:-/home/${DOCKSAL_HOST_USER}/builds}
 	export REMOTE_BUILD_DIR="${REMOTE_BUILD_BASE}/$REPO_NAME_SAFE-$BRANCH_NAME_SAFE"
 	export COMPOSE_PROJECT_NAME="$REPO_NAME_SAFE-$BRANCH_NAME_SAFE"
 	export DOCKER_STACK_NAME="$REPO_NAME_SAFE-$BRANCH_NAME_SAFE"
@@ -131,8 +133,7 @@ build_env ()
 	export DOCKSAL_HOST="${DOCKSAL_HOST:-$DOCKSAL_HOST_IP.nip.io}"
 	sed -i "s/HostName DOCKSAL_HOST/HostName $DOCKSAL_HOST/g" $HOME/.ssh/config
 
-	# Use ubuntu as the user by default
-	export DOCKSAL_HOST_USER="${DOCKSAL_HOST_USER:-ubuntu}"
+	# Set the sandbox user name in agent's SSH config
 	sed -i "s/User DOCKSAL_HOST_USER/User $DOCKSAL_HOST_USER/g" $HOME/.ssh/config
 
 	# Allow setting DOCKSAL_DOMAIN individually from DOCKSAL_HOST. Default to DOCKSAL_HOST if not set.
@@ -166,7 +167,7 @@ ssh_init ()
 	fi
 }
 
-# Configured preferred git settings
+# Configure preferred git settings
 git_env ()
 {
 	# Only set these if not already configured

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -5,6 +5,8 @@
 #
 # Usage source build-env
 
+# Note: "set -e" MUST be restored back ("set +e") at the end of the script.
+# This script is sourced, so settings will propagate to all build steps.
 set -e # Abort if anything fails
 #set -x # Echo commands
 
@@ -197,3 +199,6 @@ git_env
 # Sandbox server settings
 echo-debug "Configuring sandbox server settings..."
 sandbox_server_env
+
+# IMPORTANT! Reverting settings set at the beginning on the script
+set +e

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -150,8 +150,19 @@ build_env ()
 # Since this scripts is supposed to be sourced for every run command, the keys will be reset back to our values.
 ssh_init ()
 {
-	(umask  077 ; echo "$CI_SSH_KEY" | base64 -d > $HOME/.ssh/id_rsa; chmod 0600 $HOME/.ssh/id_rsa)
-	(umask  077 ; echo "$DOCKSAL_HOST_SSH_KEY" | base64 -d > $HOME/.ssh/docksal_host_id_rsa; chmod 0600 $HOME/.ssh/docksal_host_id_rsa)
+	[[ "$CI_SSH_KEY" != "" ]] &&
+	(
+		umask  077
+		echo "$CI_SSH_KEY" | base64 -d > $HOME/.ssh/id_rsa
+		chmod 0600 $HOME/.ssh/id_rsa
+	)
+
+	[[ "$DOCKSAL_HOST_SSH_KEY" != "" ]] &&
+	(
+		umask  077
+		echo "$DOCKSAL_HOST_SSH_KEY" | base64 -d > $HOME/.ssh/docksal_host_id_rsa
+		chmod 0600 $HOME/.ssh/docksal_host_id_rsa
+	)
 }
 
 # Configured preferred git settings

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -145,10 +145,13 @@ build_env ()
 	export DOMAIN="${BRANCH_NAME_SAFE}-${REPO_NAME_SAFE}.${DOCKSAL_DOMAIN}"
 }
 
+# Configure SSH keys
+# Note: CircleCI injects it's own key during checkout.
+# Since this scripts is supposed to be sourced for every run command, the keys will be reset back to our values.
 ssh_init ()
 {
-	(umask  077 ; echo "$CI_SSH_KEY" | base64 -d > $HOME/.ssh/id_rsa)
-	(umask  077 ; echo "$DOCKSAL_HOST_SSH_KEY" | base64 -d > $HOME/.ssh/docksal_host_id_rsa)
+	(umask  077 ; echo "$CI_SSH_KEY" | base64 -d > $HOME/.ssh/id_rsa; chmod 0600 $HOME/.ssh/id_rsa)
+	(umask  077 ; echo "$DOCKSAL_HOST_SSH_KEY" | base64 -d > $HOME/.ssh/docksal_host_id_rsa; chmod 0600 $HOME/.ssh/docksal_host_id_rsa)
 }
 
 # Configured preferred git settings

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -125,10 +125,16 @@ ssh_init ()
 	(umask  077 ; echo "$DOCKSAL_HOST_SSH_KEY" | base64 -d > $HOME/.ssh/docksal_host_id_rsa)
 }
 
+# Configured preferred git settings
 git_env ()
 {
-	git config --global user.email "$GIT_USER_EMAIL"
-	git config --global user.name "$GIT_USER_NAME"
+	# Only set these if not already configured
+	if [[ "$(git config --global user.email)" == "" ]] && [[ "$GIT_USER_EMAIL" != "" ]]; then
+		git config --global user.email "$GIT_USER_EMAIL"
+	fi
+	if [[ "$(git config --global user.name)" == "" ]] && [[ "$GIT_USER_NAME" != "" ]]; then
+		git config --global user.email "$GIT_USER_NAME"
+	fi
 }
 
 ssh_tunnel_init ()

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -46,7 +46,7 @@ build_env ()
 	# Support for Bitbucket Pipelines
 	if [[ "$BITBUCKET_REPO_SLUG" != "" ]]; then
 		echo-debug "Detected Bitbucket Pipelines build environment"
-		export BITBUCKETCI="true"
+		export BITBUCKET_CI="true"
 		export GIT_REPO_SERVICE="bitbucket"
 		export GIT_REPO_OWNER="$BITBUCKET_REPO_OWNER"
 		export GIT_REPO_NAME="$BITBUCKET_REPO_SLUG"

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -5,13 +5,10 @@
 #
 # Usage source build-env
 
-# Note: bash option set with "set" MUST be restored back at the end of the script.
-# This script is sourced, so these settings will propagate to all build steps.
-# Abort if anything fails
-set -eE  # same as: `set -o errexit -o errtrace`
-trap "echo 'Build environment initialization failed!'" ERR
-# Echo commands
-#set -x
+# IMPORTANT: This script is sourced in the build environment.
+# Any settings set here using set/trap/etc. will propagate to all build steps.
+# As such, it's best not to make any adjustment or make sure they are reverted at the end of the script.
+# E.g., instead of "set -e" use "exit 1" where necessary.
 
 # -------------------- Constants -------------------- #
 
@@ -220,6 +217,3 @@ echo-debug "Configuring sandbox server settings..."
 if [[ "$DOCKSAL_HOST_TUNNEL" != "" ]]; then
 	ssh_tunnel_init && export DOCKER_HOST=${DOCKER_HOST_TUNNEL}
 fi
-
-# IMPORTANT! Reverting settings set at the beginning on the script
-set +eE

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -117,46 +117,8 @@ build_env ()
 	export REPO_NAME_SAFE="$(safe_string ${GIT_REPO_NAME:0:${REPO_NAME_LENGTH_LIMIT}})"
 	# Short version of GIT_COMMIT_HASH
 	export COMMIT_HASH_SHORT="${GIT_COMMIT_HASH:0:7}"
-}
 
-ssh_init ()
-{
-	(umask  077 ; echo "$CI_SSH_KEY" | base64 -d > $HOME/.ssh/id_rsa)
-	(umask  077 ; echo "$DOCKSAL_HOST_SSH_KEY" | base64 -d > $HOME/.ssh/docksal_host_id_rsa)
-}
-
-# Configured preferred git settings
-git_env ()
-{
-	# Only set these if not already configured
-	if [[ "$(git config --global user.email)" == "" ]] && [[ "$GIT_USER_EMAIL" != "" ]]; then
-		git config --global user.email "$GIT_USER_EMAIL"
-	fi
-	if [[ "$(git config --global user.name)" == "" ]] && [[ "$GIT_USER_NAME" != "" ]]; then
-		git config --global user.email "$GIT_USER_NAME"
-	fi
-}
-
-ssh_tunnel_init ()
-{
-	# Check if the tunnel is already active and return if so
-	ssh -O "check" docker-host >/dev/null 2>&1
-	[[ $? == 0 ]] && return 0
-
-	echo "Setting up a secure tunnel to the Docker Engine on $DOCKSAL_HOST..."
-	# Black magic! Remote docker.sock access over SSH tunnel
-	# Credits:
-	# https://docs.docker.com/docker-for-aws/deploy/#connecting-via-ssh
-	# https://gist.github.com/scy/6781836#gistcomment-1559506
-	ssh -fM -NL ${DOCKER_HOST_TUNNEL}:/var/run/docker.sock docker-host
-
-	echo "Querying Docker Engine..."
-	docker --host ${DOCKER_HOST_TUNNEL} version
-	return $?
-}
-
-sandbox_server_env ()
-{
+	# Sandbox settings
 	export REMOTE_BUILD_BASE=${REMOTE_BUILD_BASE:-/home/ubuntu/builds}
 	export REMOTE_BUILD_DIR="${REMOTE_BUILD_BASE}/$REPO_NAME_SAFE-$BRANCH_NAME_SAFE"
 	export COMPOSE_PROJECT_NAME="$REPO_NAME_SAFE-$BRANCH_NAME_SAFE"
@@ -181,13 +143,43 @@ sandbox_server_env ()
 	# "www.sub-domain.example.com".
 	# NOTE: The length of any one label (sub-domain) in the domain name is limited to 63 octets (characters).
 	export DOMAIN="${BRANCH_NAME_SAFE}-${REPO_NAME_SAFE}.${DOCKSAL_DOMAIN}"
+}
 
-	# Initialize a tunnel to the Docker Engine on DOCKSAL_HOST
-	# Export local tunnel connection settings if it works
-	# Using full if form instead of the short one here, otherwise builds will fail, when the condition below is false
-	if [[ "$DOCKSAL_HOST_TUNNEL" != "" ]]; then
-		ssh_tunnel_init && export DOCKER_HOST=${DOCKER_HOST_TUNNEL}
+ssh_init ()
+{
+	(umask  077 ; echo "$CI_SSH_KEY" | base64 -d > $HOME/.ssh/id_rsa)
+	(umask  077 ; echo "$DOCKSAL_HOST_SSH_KEY" | base64 -d > $HOME/.ssh/docksal_host_id_rsa)
+}
+
+# Configured preferred git settings
+git_env ()
+{
+	# Only set these if not already configured
+	if [[ "$(git config --global user.email)" == "" ]] && [[ "$GIT_USER_EMAIL" != "" ]]; then
+		git config --global user.email "$GIT_USER_EMAIL"
 	fi
+	if [[ "$(git config --global user.name)" == "" ]] && [[ "$GIT_USER_NAME" != "" ]]; then
+		git config --global user.email "$GIT_USER_NAME"
+	fi
+}
+
+# Support running docker commands (locally to the agent) on the sandbox server (remote Docker engine)
+ssh_tunnel_init ()
+{
+	# Check if the tunnel is already active and return if so
+	ssh -O "check" docker-host >/dev/null 2>&1
+	[[ $? == 0 ]] && return 0
+
+	echo "Setting up a secure tunnel to the Docker Engine on $DOCKSAL_HOST..."
+	# Black magic! Remote docker.sock access over SSH tunnel
+	# Credits:
+	# https://docs.docker.com/docker-for-aws/deploy/#connecting-via-ssh
+	# https://gist.github.com/scy/6781836#gistcomment-1559506
+	ssh -fM -NL ${DOCKER_HOST_TUNNEL}:/var/run/docker.sock docker-host
+
+	echo "Querying Docker Engine..."
+	docker --host ${DOCKER_HOST_TUNNEL} version
+	return $?
 }
 
 # -------------------- Runtime -------------------- #
@@ -204,7 +196,12 @@ git_env
 
 # Sandbox server settings
 echo-debug "Configuring sandbox server settings..."
-sandbox_server_env
+# Initialize a tunnel to the Docker Engine on DOCKSAL_HOST
+# Export local tunnel connection settings if it works
+# Using full "if" form instead of the short one here, otherwise build fails, when the condition below is false
+if [[ "$DOCKSAL_HOST_TUNNEL" != "" ]]; then
+	ssh_tunnel_init && export DOCKER_HOST=${DOCKER_HOST_TUNNEL}
+fi
 
 # IMPORTANT! Reverting settings set at the beginning on the script
 set +e

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -5,10 +5,13 @@
 #
 # Usage source build-env
 
-# Note: "set -e" MUST be restored back ("set +e") at the end of the script.
-# This script is sourced, so settings will propagate to all build steps.
-set -e # Abort if anything fails
-#set -x # Echo commands
+# Note: bash option set with "set" MUST be restored back at the end of the script.
+# This script is sourced, so these settings will propagate to all build steps.
+# Abort if anything fails
+set -eE  # same as: `set -o errexit -o errtrace`
+trap "echo 'Build environment initialization failed!'" ERR
+# Echo commands
+#set -x
 
 # -------------------- Constants -------------------- #
 
@@ -219,4 +222,4 @@ if [[ "$DOCKSAL_HOST_TUNNEL" != "" ]]; then
 fi
 
 # IMPORTANT! Reverting settings set at the beginning on the script
-set +e
+set +eE

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -56,6 +56,7 @@ build_env ()
 		# Bitbucket Pipelines does not work with PRs
 		#GIT_PR_NUMBER=?
 
+		export BUILD_ID="$BITBUCKET_BUILD_NUMBER"
 		export BUILD_DIR="$BITBUCKET_CLONE_DIR"
 	fi
 
@@ -81,6 +82,7 @@ build_env ()
 			export GIT_PR_NUMBER=${CIRCLE_PULL_REQUEST##*/}
 		fi
 
+		export BUILD_ID="$CIRCLE_BUILD_NUM"
 		export BUILD_DIR="$CIRCLE_WORKING_DIRECTORY"
 	fi
 
@@ -95,6 +97,7 @@ build_env ()
 		export GIT_COMMIT_HASH="$CI_COMMIT_SHA"
 		export GIT_PR_NUMBER="$CI_MERGE_REQUEST_ID"
 
+		export BUILD_ID="$CI_JOB_ID"
 		export BUILD_DIR="$CI_PROJECT_DIR"
 	fi
 

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -153,19 +153,17 @@ build_env ()
 # Since this scripts is supposed to be sourced for every run command, the keys will be reset back to our values.
 ssh_init ()
 {
-	[[ "$CI_SSH_KEY" != "" ]] &&
-	(
+	if [[ "$CI_SSH_KEY" != "" ]]; then
 		umask  077
 		echo "$CI_SSH_KEY" | base64 -d > $HOME/.ssh/id_rsa
 		chmod 0600 $HOME/.ssh/id_rsa
-	)
+	fi
 
-	[[ "$DOCKSAL_HOST_SSH_KEY" != "" ]] &&
-	(
+	if [[ "$DOCKSAL_HOST_SSH_KEY" != "" ]]; then
 		umask  077
 		echo "$DOCKSAL_HOST_SSH_KEY" | base64 -d > $HOME/.ssh/docksal_host_id_rsa
 		chmod 0600 $HOME/.ssh/docksal_host_id_rsa
-	)
+	fi
 }
 
 # Configured preferred git settings

--- a/base/config/.ssh/config
+++ b/base/config/.ssh/config
@@ -1,12 +1,19 @@
-# Disable the host key check
+# All hosts
 Host *
+	# Disable the host key check
 	StrictHostKeyChecking no
 	UserKnownHostsFile=/dev/null
 	LogLevel ERROR
+	# Force using the key set via CI_SSH_KEY for all hosts
+	IdentityFile ~/.ssh/id_rsa
+	IdentitiesOnly yes
 
+# Docksal Sandbox Server
+# TODO: rename to dss instead of docker-host in 2.0
 Host docker-host
 	HostName DOCKSAL_HOST
 	User DOCKSAL_HOST_USER
+	# Disable the host key check
 	StrictHostKeyChecking no
 	UserKnownHostsFile=/dev/null
 	LogLevel ERROR

--- a/examples/.circleci/config.yml
+++ b/examples/.circleci/config.yml
@@ -7,17 +7,17 @@ jobs:
     docker:
       - image: docksal/ci-agent:php
     steps:
-      # Code checkout in the build agent
-      - checkout
       # Inject build environment variables.
       # Each run statement runs in its own isolated shell (exported variables are not preserved).
       # $BASH_ENV can be used to pass environment variables between run statements.
       - run:
           name: Configure agent environment
           command: echo 'source build-env' > $BASH_ENV
+      # Code checkout in the build agent
+      - checkout
       # Launch a sandbox on the sandbox server
       - run:
-          name: Provision sandbox
+          name: Build sandbox
           command: sandbox-init
       # Run other commands
       - run:

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -3,7 +3,8 @@ FROM docksal/ci-agent:base
 # Switch to root to install some system-wide stuff
 USER root
 
-RUN apk add --update --no-cache \
+RUN set -xe; \
+	apk add --update --no-cache \
 		php7 \
 		php7-ctype \
 		php7-curl \
@@ -25,7 +26,7 @@ ENV COMPOSER_VERSION=1.6.3
 ENV DRUSH_VERSION 8.1.16
 ENV DRUPAL_CONSOLE_VERSION 1.7.0
 ENV WPCLI_VERSION 1.5.0
-RUN \
+RUN set -xe; \
 	# Composer
 	curl -sSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
 	# Drush 8 (default)
@@ -41,7 +42,7 @@ RUN \
 USER $AGENT_USER
 
 ENV PATH $PATH:$AGENT_HOME/.composer/vendor/bin
-RUN \
+RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$AGENT_HOME/.composer/vendor/bin"' >> $AGENT_HOME/.profile; \
 	# Drush modules

--- a/tests/php.bats
+++ b/tests/php.bats
@@ -54,6 +54,11 @@ teardown() {
 	echo "$output" | grep "WP-CLI"
 	unset output
 
+	run make exec COMMAND="phpcs --version"
+	[[ "$status" == 0 ]]
+	echo "$output" | grep "PHP_CodeSniffer"
+	unset output
+
 	### Cleanup ###
 	make clean
 }


### PR DESCRIPTION
- Switched to Alpine 3.8
- Added `make` package
- Miscellaneous improvements in build environment initialization (`build-env`)
  - **[BREAKING CHANGE]** Updated defaults for the sandbox user and builds directory
    - User: `build-agent`; builds directory: `/home/build-agent/builds`
    - These can be overridden via DOCKSAL_HOST_USER and REMOTE_BUILD_BASE respectively
  - Removed "set -e" option in `build-env`
    - Since `build-env` is sourced in all build steps, the "set -e" setting was propagated everywhere causing build steps to fail on any error. This can be especially nasty when `npm` packages installed from source fail to compile without obvious reasons.
  - Improved `git_env` and `ssh_init` - only write configs when necessary
  - Force using the key set via `CI_SSH_KEY` for all hosts. Fixes #26
  - Renamed `BITBUCKETCI` to `BITBUCKET_CI`
    - This variable is used internally and is set to "true" when a build is running on Bitbucket Pipelines
  - Added `BUILD_ID` variable - used as the unique identifier for a build
- Updated docs
  - configuring SSH keys
  - CircleCI basic example
    - Doing "echo 'source build-env' >> $BASH_ENV" as the first step is important for CircleCI builds. Each run statement runs in its own isolated shell (exported variables are not preserved). $BASH_ENV can be used to pass environment variables between run statements.
- Updated tests
