### PR TITLE
Release 1.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ shell: clean
 	docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(VERSION) /bin/bash -oe pipefail
 
 exec:
+	# Note: variables defined inside COMMAND get interpreted on the host, unless escaped, e.g. \$${CI_SSH_KEY}.
 	docker exec $(NAME) /bin/bash -oe pipefail -c "$(COMMAND)"
 
 run: clean
@@ -35,7 +36,7 @@ logs:
 	docker logs $(NAME)
 
 clean:
-	docker rm -f $(NAME) &>/dev/null || true
+	docker rm -f $(NAME) || true
 
 release: build
 	make push -e VERSION=$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ push:
 	docker push $(REPO):$(VERSION)
 
 shell: clean
-	docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(VERSION) /bin/bash
+	docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(VERSION) /bin/bash -oe pipefail
 
 exec:
-	docker exec $(NAME) $(COMMAND)
+	docker exec $(NAME) /bin/bash -oe pipefail -c "$(COMMAND)"
 
 run: clean
 	docker run --rm --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(VERSION)
@@ -35,7 +35,7 @@ logs:
 	docker logs $(NAME)
 
 clean:
-	docker rm -f $(NAME) || true
+	docker rm -f $(NAME) &>/dev/null || true
 
 release: build
 	make push -e VERSION=$(VERSION)

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash -eo pipefail
 
 # Configures build environment variables
 # This file should be sources at the beginning of a build
@@ -7,8 +7,6 @@
 
 # IMPORTANT: This script is sourced in the build environment.
 # Any settings set here using set/trap/etc. will propagate to all build steps.
-# As such, it's best not to make any adjustment or make sure they are reverted at the end of the script.
-# E.g., instead of "set -e" use "exit 1" where necessary.
 
 # -------------------- Constants -------------------- #
 

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -45,8 +45,12 @@ build_env ()
 {
 	# Drop variables with "null" values
 	# This allows, at the project level, unsetting build variables set at the org level
-	empty_vars="$(env | grep '=null$' | cut -d = -f 1)"
-	while read -r i; do unset ${i}; done <<< "${empty_vars}"
+	if empty_vars="$(env | grep '=null$' | cut -d = -f 1)"; then
+		while read -r i; do
+			echo-debug "Dropping the '${i}' variable with a 'null' value..."
+			unset ${i};
+		done <<< "${empty_vars}"
+	fi
 
 	# Support for Bitbucket Pipelines
 	if [[ "$BITBUCKET_REPO_SLUG" != "" ]]; then

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -48,14 +48,12 @@ teardown() {
 
 	### Tests ###
 	# Check git settings were applied
-	run make exec COMMAND="build-env"
-	run make exec COMMAND="git config --get --global user.email"
+	run make exec COMMAND='bash -c "source build-env; git config --get --global user.email"'
 	[[ "$status" == 0 ]]
 	echo "$output" | grep "git@example.com"
 	unset output
 
-	run make exec COMMAND="build-env"
-	run make exec COMMAND="git config --get --global user.name"
+	run make exec COMMAND='bash -c "source build-env; git config --get --global user.name"'
 	[[ "$status" == 0 ]]
 	echo "$output" | grep "Docksal CLI"
 	unset output
@@ -70,17 +68,16 @@ teardown() {
 	### Setup ###
 	CI_SSH_KEY="LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUkxOElNMTZEMFVsS0U0VHVYeU1iQ3NEb3VHWU9TZC85SkJmSTcrenFCQ1JvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFK1BSR2RQOUpSTmljbVQ1RjR1WFNEakV2TXFUczAxaVVOTXprTXAzUVdSM3hScWp5VFlYdAp0R1hRNE5BVWlxWEtlMnNaN0NZMmxqeGNrTUJCamU2OEhBPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
 	make start -e ENV="-e GIT_USER_EMAIL='git@example.com' -e GIT_USER_NAME='Docksal CLI' -e GIT_REPO_URL='test-repo-url' -e GIT_BRANCH_NAME='test-branch-name' -e GIT_COMMIT_HASH='test-commit-hash' -e CI_SSH_KEY='${CI_SSH_KEY}'"
-	make exec COMMAND="build-env"
 
 	### Tests ###
 
 	# Check private SSH key
-	run make exec COMMAND='bash -lc "echo \$$CI_SSH_KEY | base64 -d | diff \$$HOME/.ssh/id_rsa -"'
+	run make exec COMMAND='bash -c "source build-env; echo \$$CI_SSH_KEY | base64 -d | diff \$$HOME/.ssh/id_rsa -"'
 	[[ "$status" == 0 ]]
 	unset output
 
 	# Check ssh-agent
-	run make exec COMMAND='bash -lc "source build-env; ssh-add -l"'
+	run make exec COMMAND='bash -c "source build-env; ssh-add -l"'
 	[[ "$status" == 0 ]]
 	unset output
 

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -10,9 +10,8 @@ teardown() {
 	echo "================================================================"
 }
 
-# Global skip
-# Uncomment below, then comment skip in the test you want to debug. When done, reverse.
-#SKIP=1
+# To work on a specific test:
+# run `export SKIP=1` locally, then comment skip in the test you want to debug
 
 @test "Check binaries" {
 	[[ $SKIP == 1 ]] && skip
@@ -48,12 +47,12 @@ teardown() {
 
 	### Tests ###
 	# Check git settings were applied
-	run make exec COMMAND='bash -c "source build-env; git config --get --global user.email"'
+	run make exec COMMAND="source build-env; git config --get --global user.email"
 	[[ "$status" == 0 ]]
 	echo "$output" | grep "git@example.com"
 	unset output
 
-	run make exec COMMAND='bash -c "source build-env; git config --get --global user.name"'
+	run make exec COMMAND="source build-env; git config --get --global user.name"
 	[[ "$status" == 0 ]]
 	echo "$output" | grep "Docksal CLI"
 	unset output
@@ -72,12 +71,14 @@ teardown() {
 	### Tests ###
 
 	# Check private SSH key
-	run make exec COMMAND='bash -c "source build-env; echo \$$CI_SSH_KEY | base64 -d | diff \$$HOME/.ssh/id_rsa -"'
+	# COMMAND is wrapped in double quotes in Makefile, so variables defined inside it get interpreted on the host,
+	# unless escaped, e.g. \$${CI_SSH_KEY}
+	run make exec COMMAND='source build-env; echo \$${CI_SSH_KEY} | base64 -d | diff \$${HOME}/.ssh/id_rsa -'
 	[[ "$status" == 0 ]]
 	unset output
 
 	# Check ssh-agent
-	run make exec COMMAND='bash -c "source build-env; ssh-add -l"'
+	run make exec COMMAND="source build-env; ssh-add -l"
 	[[ "$status" == 0 ]]
 	unset output
 

--- a/tests/php.bats
+++ b/tests/php.bats
@@ -10,9 +10,8 @@ teardown() {
 	echo "================================================================"
 }
 
-# Global skip
-# Uncomment below, then comment skip in the test you want to debug. When done, reverse.
-#SKIP=1
+# To work on a specific test:
+# run `export SKIP=1` locally, then comment skip in the test you want to debug
 
 @test "Base tests" {
 	[[ $SKIP == 1 ]] && skip


### PR DESCRIPTION
- Fixed handling of "null" variables. Fixes #35
- Switch to using `/bin/bash -oe pipefail` in build-env and Makefile commands
  - Make it closer to the way CircleCI and others run scripts.
  - TODO: revise and update other built-in scripts to use `/bin/bash -oe pipefail` as well.
- Updated tests
