### PR TITLE
Add build-preserve command.

### DIFF
--- a/base/bin/build-preserve
+++ b/base/bin/build-preserve
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+dir_exists=$(ssh docker-host "[ -d $REMOTE_BUILD_DIR ]")
+result=$?
+if [ $result == "0" ]; then
+  # Directory exists so lets pull and reset.
+  build-exec "git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME"
+else
+  # Directory does not exist, must clone.
+  build-init
+fi


### PR DESCRIPTION
Description:

Alternative to build-init which instead preserves the file state of the build directory. Useful for speeding up builds when usage of build minutes is a concern, especially on large repositories.

Run-through of command:

1) Check to see if the build directory already exists in the sandbox environment.
2) If directory already exists, git fetch and do a hard reset to the working branch.
3) If the directory does not exist, run build-init normally.