### PR TITLE
Disable wrapping in example base64 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If using `DOCKSAL_HOST_IP`, the agent will use `nip.io` for dynamic wildcard dom
 
 A base64 encoded private SSH key, used to access the remote Docksal host.
 
-Note: `cat /path/to/<private_key_file> | base64 -w 0` can be used to create a base64 encoded string from a private SSH key.
+Note: `cat /path/to/<private_key_file> | base64` can be used to create a base64 encoded string from a private SSH key (on Linux `cat /path/to/<private_key_file> | base64 -w 0` can be used to avoid wrapping).
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If using `DOCKSAL_HOST_IP`, the agent will use `nip.io` for dynamic wildcard dom
 
 A base64 encoded private SSH key, used to access the remote Docksal host.
 
-Note: `cat /path/to/<private_key_file> | base64` can be used to create a base64 encoded string from a private SSH key.
+Note: `cat /path/to/<private_key_file> | base64 -w 0` can be used to create a base64 encoded string from a private SSH key.
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If using `DOCKSAL_HOST_IP`, the agent will use `nip.io` for dynamic wildcard dom
 
 A base64 encoded private SSH key, used to access the remote Docksal host.
 
-Note: on macOS `cat /path/to/<private_key_file> | base64` can be used to create a base64 encoded string from a private SSH key (on Linux, WSL in Windows 10 or in Babun `cat /path/to/<private_key_file> | base64 -w 0` should be used to avoid output wrapping of the `base64` command).
+Note: on macOS `cat /path/to/<private_key_file> | base64` can be used to create a base64 encoded string from a private SSH key (on Linux, in WSL on Windows 10 and in Babun `cat /path/to/<private_key_file> | base64 -w 0` should be used to avoid output wrapping of the `base64` command).
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If using `DOCKSAL_HOST_IP`, the agent will use `nip.io` for dynamic wildcard dom
 
 A base64 encoded private SSH key, used to access the remote Docksal host.
 
-Note: on macOS `cat /path/to/<private_key_file> | base64` can be used to create a base64 encoded string from a private SSH key (on Linux, in WSL on Windows 10 and in Babun `cat /path/to/<private_key_file> | base64 -w 0` should be used to avoid output wrapping of the `base64` command).
+Note: on macOS `cat /path/to/<private_key_file> | base64` can be used to create a base64 encoded string from a private SSH key, while on Linux, in WSL on Windows 10 and in Babun `cat /path/to/<private_key_file> | base64 -w 0` should be used to avoid output wrapping of the `base64` command).
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If using `DOCKSAL_HOST_IP`, the agent will use `nip.io` for dynamic wildcard dom
 
 A base64 encoded private SSH key, used to access the remote Docksal host.
 
-Note: `cat /path/to/<private_key_file> | base64` can be used to create a base64 encoded string from a private SSH key (on Linux `cat /path/to/<private_key_file> | base64 -w 0` can be used to avoid wrapping).
+Note: on macOS `cat /path/to/<private_key_file> | base64` can be used to create a base64 encoded string from a private SSH key (on Linux, WSL in Windows 10 or in Babun `cat /path/to/<private_key_file> | base64 -w 0` should be used to avoid output wrapping of the `base64` command).
 
 ### Optional
 


### PR DESCRIPTION
The example base64 command in the README wraps output on my computer (ubuntu 16.04). Adding the `-w 0` tells the command not to wrap output no matter what the default may be.