### PR TITLE
Add method for preserving previous builds during build-init.

### DIFF
--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -14,6 +14,7 @@ DEBUG=${DEBUG:-0}  # `DEBUG=1 build-env` to run with debugging turned ON
 DOCKER_HOST_TUNNEL=localhost:2374
 GIT_USER_EMAIL=${GIT_USER_EMAIL:-ci@docksal.io}
 GIT_USER_NAME=${GIT_USER_NAME:-Docksal CI}
+REMOTE_BUILD_DIR_CLEANUP=${REMOTE_BUILD_DIR_CLEANUP:-1} # Default to re-initializing environment.
 
 # These are used to generate the sandbox sub-domain (branch-project.example.com)
 # There is a limit of 63 characters for any part of the domain name.

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -71,6 +71,6 @@ if [[ "${secrets}" != "" ]]; then
 	echo "Passing build secrets to sandbox..."
 	for secret in $secrets
 	do
-		build-exec "fin config set $secret=${!secret} --env=local >/dev/null"
+		build-exec "fin config set $secret='${!secret}' --env=local >/dev/null"
 	done
 fi

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -7,9 +7,9 @@ set -e # Abort if anything fails
 
 # Cleanup
 echo "Setting up remote build environment..."
-if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == 1 ]] || [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
+if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == "1" ]] || [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
 	echo "Re-initializing remote environment from scratch..."
-	[[ "${REMOTE_BUILD_DIR_CLEANUP}" == 0 ]] && [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]] && echo "rsync is not supported for preserved builds!"
+	[[ "${REMOTE_BUILD_DIR_CLEANUP}" == "0" ]] && [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]] && echo "rsync is not supported for preserved builds!"
 	ssh docker-host "(cd ${REMOTE_BUILD_DIR} 2>/dev/null && fin rm -f 2>/dev/null) || true"
 	ssh docker-host "sudo rm -rf ${REMOTE_BUILD_DIR} 2>/dev/null; mkdir -p ${REMOTE_BUILD_DIR}"
 else
@@ -28,7 +28,7 @@ if [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
 else
 	# Checkout sources on the remote host
 	echo "Checking out codebase via git..."
-	if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == 1 ]]; then
+	if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == "1" ]]; then
 		build-exec "git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la"
 	else
 		build-exec "(git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME && ls -la) || (git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la)"

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -40,7 +40,8 @@ fi
 
 # Remote codebase initialization method. Either 'rsync' (default) or 'git'
 if [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
-	# Rsync sources to the remote host
+	# Rsync sources to the remote host. Exclude root .git to make switching to
+	# a git codebase method later possible without error.
 	echo "Syncing codebase via rsync..."
 	rsync --delete --exclude='/.git' -az ${BUILD_DIR}/ docker-host:${REMOTE_BUILD_DIR}
 else

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -39,23 +39,18 @@ fi
 echo "Configuring sandbox settings..."
 build-exec "fin config set COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} --env=local"
 build-exec "fin config set VIRTUAL_HOST=${SANDBOX_DOMAIN} --env=local"
-#build-exec "echo COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} | tee -a .docksal/docksal-local.env"
-#build-exec "echo VIRTUAL_HOST=${SANDBOX_DOMAIN} | tee -a .docksal/docksal-local.env"
 
 # Basic HTTP Auth
 if [[ "${HTTP_USER}" != "" ]] && [[ "${HTTP_PASS}" != "" ]]; then
 	echo "Configuring sandbox Basic HTTP Authentication..."
 	build-exec "fin config set APACHE_BASIC_AUTH_USER=${HTTP_USER} --env=local"
 	build-exec "fin config set APACHE_BASIC_AUTH_PASS=${HTTP_PASS} --env=local"
-	# build-exec "echo APACHE_BASIC_AUTH_USER=${HTTP_USER} | tee -a .docksal/docksal-local.env"
-	# build-exec "echo APACHE_BASIC_AUTH_PASS=${HTTP_PASS} | tee -a .docksal/docksal-local.env"
 fi
 
 # Permanent environment switch
 if [[ "${SANDBOX_PERMANENT}" != "" ]]; then
 	echo "Setting sandbox as permanent..."
 	build-exec "fin config set SANDBOX_PERMANENT=${SANDBOX_PERMANENT} --env=local"
-	# build-exec "echo SANDBOX_PERMANENT=${SANDBOX_PERMANENT} | tee -a .docksal/docksal-local.env"
 fi
 
 # Pass CI_SSH_KEY to sandbox
@@ -78,5 +73,4 @@ if [[ "${secrets}" != "" ]]; then
 	do
 		build-exec "fin config set $secret=${!secret} --env=local >/dev/null"
 	done
-	# build-exec "echo '${secrets}' | tee -a .docksal/docksal-local.env >/dev/null"
 fi

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -2,8 +2,9 @@
 
 # This script sets up a sandbox environment for the build on the remote docker host.
 
+# Exit if using an invalid codebase method.
 if [[ "${REMOTE_CODEBASE_METHOD}" != "rsync" ]] && [[ "${REMOTE_CODEBASE_METHOD}" != "git" ]]; then
-	echo "Only rsync and git codebase methods are supported. ${REMOTE_CODEBASE_METHOD} method given. Aborting."
+	echo "Only rsync and git codebase methods are supported. '${REMOTE_CODEBASE_METHOD}' method given. Aborting."
 	exit 1
 fi
 
@@ -21,9 +22,7 @@ set -e # Abort if anything fails
 # 1) REMOTE_BUILD_DIR_CLEANUP is set to 1.
 # 2) rsync is the supported method of transferring the codebase.
 # 3) git is the supported method but the remote directory either doesn't exist
-#    or is not a git repository, signaling a possible build method switch from
-#    rsync -> git, or the directory was somehow created outside of the agent's
-#    purview.
+#    or is not a git repository.
 # 4) git is the supported method but the remote build directory does not exist yet.
 echo "Cleaning up remote build environment..."
 if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == "1" ]] ||
@@ -43,7 +42,7 @@ fi
 if [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
 	# Rsync sources to the remote host
 	echo "Syncing codebase via rsync..."
-	rsync --delete -az ${BUILD_DIR}/ docker-host:${REMOTE_BUILD_DIR}
+	rsync --delete --exclude='/.git' -az ${BUILD_DIR}/ docker-host:${REMOTE_BUILD_DIR}
 else
 	# Checkout sources on the remote host
 	echo "Checking out codebase via git..."

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -2,7 +2,7 @@
 
 # This script sets up a sandbox environment for the build on the remote docker host.
 
-if [[ "${REMOTE_CODEBASE_METHOD}" != "rsync" ]] || [[ "${REMOTE_CODEBASE_METHOD}" != "git" ]]; then
+if [[ "${REMOTE_CODEBASE_METHOD}" != "rsync" ]] && [[ "${REMOTE_CODEBASE_METHOD}" != "git" ]]; then
 	echo "Only rsync and git codebase methods are supported. ${REMOTE_CODEBASE_METHOD} method given. Aborting."
 	exit 1
 fi

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -2,6 +2,11 @@
 
 # This script sets up a sandbox environment for the build on the remote docker host.
 
+if [[ "${REMOTE_CODEBASE_METHOD}" != "rsync" ]] || [[ "${REMOTE_CODEBASE_METHOD}" != "git" ]]; then
+	echo "Only rsync and git codebase methods are supported. ${REMOTE_CODEBASE_METHOD} method given. Aborting."
+	exit 1
+fi
+
 # Collect information surrounding the existence of the remote build directory,
 # and whether or not it is a Git repository.
 ssh docker-host "[ -d $REMOTE_BUILD_DIR ]"

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -65,8 +65,11 @@ fi
 # Pass build secrets to sandbox
 # A "secret" is any environment variable that starts with "SECRET_"
 
+# Parse all environment variables for those prefixed with SECRET_ and then
+# inject each variable/value pair into docksal-local.env. This allows you to
+# add secure variables to your project's repository that can be injected into
+# each sandbox environment.
 secrets="$(compgen -A variable | grep '^SECRET_')" || true
-# secrets="$(env | grep '^SECRET_')" || true
 if [[ "${secrets}" != "" ]]; then
 	echo "Passing build secrets to sandbox..."
 	for secret in $secrets

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -31,7 +31,7 @@ else
 	if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == 1 ]]; then
 		build-exec "git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la"
 	else
-		build-exec "git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME"
+		build-exec "(git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME >/dev/null) || (git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la)"
 	fi
 fi
 
@@ -72,7 +72,6 @@ fi
 
 secrets="$(compgen -A variable | grep '^SECRET_')" || true
 # secrets="$(env | grep '^SECRET_')" || true
-done
 if [[ "${secrets}" != "" ]]; then
 	echo "Passing build secrets to sandbox..."
 	for secret in $secrets

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -7,8 +7,16 @@ set -e # Abort if anything fails
 
 # Cleanup
 echo "Setting up remote build environment..."
-ssh docker-host "(cd ${REMOTE_BUILD_DIR} 2>/dev/null && fin rm -f 2>/dev/null) || true"
-ssh docker-host "sudo rm -rf ${REMOTE_BUILD_DIR} 2>/dev/null; mkdir -p ${REMOTE_BUILD_DIR}"
+if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == 1 ]] || [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
+	echo "Re-initializing remote environment from scratch..."
+	[[ "${REMOTE_BUILD_DIR_CLEANUP}" == 0 ]] && [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]] && echo "rsync is not supported for preserved builds!"
+	ssh docker-host "(cd ${REMOTE_BUILD_DIR} 2>/dev/null && fin rm -f 2>/dev/null) || true"
+	ssh docker-host "sudo rm -rf ${REMOTE_BUILD_DIR} 2>/dev/null; mkdir -p ${REMOTE_BUILD_DIR}"
+else
+	echo "Cleanup disabled, only applying new changes on remote environment..."
+	# Ensure directory exists. 
+	ssh docker-host "mkdir -p ${REMOTE_BUILD_DIR}"
+fi
 
 # Note: build-exec = ssh docker-host "cd $REMOTE_BUILD_DIR && ($@)"
 
@@ -20,25 +28,42 @@ if [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
 else
 	# Checkout sources on the remote host
 	echo "Checking out codebase via git..."
-	build-exec "git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la"
+	if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == 1 ]]; then
+		build-exec "git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la"
+	else
+		dir_exists=$(ssh docker-host "[ -d $REMOTE_BUILD_DIR ]")
+		result=$?
+		if [ $result == "0" ]; then
+		  # Directory exists so lets pull and reset.
+		  # Uncomment for git control.
+		  build-exec "git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME"
+		  # Uncomment for rsync control.
+		  #  rsync --delete -az ${BUILD_DIR}/ docker-host:${REMOTE_BUILD_DIR}
+		else
+	fi
 fi
 
 # Configure sandbox settings
 echo "Configuring sandbox settings..."
-build-exec "echo COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} | tee -a .docksal/docksal-local.env"
-build-exec "echo VIRTUAL_HOST=${DOMAIN} | tee -a .docksal/docksal-local.env"
+build-exec "fin config set COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} --env=local"
+build-exec "fin config set VIRTUAL_HOST=${DOMAIN} --env=local"
+#build-exec "echo COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} | tee -a .docksal/docksal-local.env"
+#build-exec "echo VIRTUAL_HOST=${DOMAIN} | tee -a .docksal/docksal-local.env"
 
 # Basic HTTP Auth
 if [[ "${HTTP_USER}" != "" ]] && [[ "${HTTP_PASS}" != "" ]]; then
 	echo "Configuring sandbox Basic HTTP Authentication..."
-	build-exec "echo APACHE_BASIC_AUTH_USER=${HTTP_USER} | tee -a .docksal/docksal-local.env"
-	build-exec "echo APACHE_BASIC_AUTH_PASS=${HTTP_PASS} | tee -a .docksal/docksal-local.env"
+	build-exec "fin config set APACHE_BASIC_AUTH_USER=${HTTP_USER} --env=local"
+	build-exec "fin config set APACHE_BASIC_AUTH_PASS=${HTTP_PASS} --env=local"
+	# build-exec "echo APACHE_BASIC_AUTH_USER=${HTTP_USER} | tee -a .docksal/docksal-local.env"
+	# build-exec "echo APACHE_BASIC_AUTH_PASS=${HTTP_PASS} | tee -a .docksal/docksal-local.env"
 fi
 
 # Permanent environment switch
 if [[ "${SANDBOX_PERMANENT}" != "" ]]; then
 	echo "Setting sandbox as permanent..."
-	build-exec "echo SANDBOX_PERMANENT=${SANDBOX_PERMANENT} | tee -a .docksal/docksal-local.env"
+	build-exec "fin config set SANDBOX_PERMANENT=${SANDBOX_PERMANENT} --env=local"
+	# build-exec "echo SANDBOX_PERMANENT=${SANDBOX_PERMANENT} | tee -a .docksal/docksal-local.env"
 fi
 
 # Pass CI_SSH_KEY to sandbox
@@ -52,8 +77,15 @@ fi
 
 # Pass build secrets to sandbox
 # A "secret" is any environment variable that starts with "SECRET_"
-secrets="$(env | grep '^SECRET_')" || true
+
+secrets="$(compgen -A variable | grep '^SECRET_')" || true
+# secrets="$(env | grep '^SECRET_')" || true
+done
 if [[ "${secrets}" != "" ]]; then
 	echo "Passing build secrets to sandbox..."
-	build-exec "echo '${secrets}' | tee -a .docksal/docksal-local.env >/dev/null"
+	for secret in $secrets
+	do
+		build-exec "fin config set $secret=${!secret} --env=local >/dev/null"
+	done
+	# build-exec "echo '${secrets}' | tee -a .docksal/docksal-local.env >/dev/null"
 fi

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -31,15 +31,7 @@ else
 	if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == 1 ]]; then
 		build-exec "git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la"
 	else
-		dir_exists=$(ssh docker-host "[ -d $REMOTE_BUILD_DIR ]")
-		result=$?
-		if [ $result == "0" ]; then
-		  # Directory exists so lets pull and reset.
-		  # Uncomment for git control.
-		  build-exec "git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME"
-		  # Uncomment for rsync control.
-		  #  rsync --delete -az ${BUILD_DIR}/ docker-host:${REMOTE_BUILD_DIR}
-		else
+		build-exec "git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME"
 	fi
 fi
 

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -31,7 +31,7 @@ else
 	if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == 1 ]]; then
 		build-exec "git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la"
 	else
-		build-exec "(git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME >/dev/null) || (git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la)"
+		build-exec "(git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME) || (git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la)"
 	fi
 fi
 

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -31,7 +31,7 @@ else
 	if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == 1 ]]; then
 		build-exec "git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la"
 	else
-		build-exec "(git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME) || (git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la)"
+		build-exec "(git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME && ls -la) || (git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la)"
 	fi
 fi
 

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -2,25 +2,39 @@
 
 # This script sets up a sandbox environment for the build on the remote docker host.
 
+# Collect information surrounding the existence of the remote build directory,
+# and whether or not it is a Git repository.
+ssh docker-host "[ -d $REMOTE_BUILD_DIR ]"
+remote_build_dir_exists_check_result=$?
+ssh docker-host "[ -d $REMOTE_BUILD_DIR/.git ]"
+remote_git_check_result=$?
+
 set -e # Abort if anything fails
 #set -x # Echo commands
 
-# Cleanup
-echo "Setting up remote build environment..."
-if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == "1" ]] || [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
-	echo "Re-initializing remote environment from scratch..."
-	[[ "${REMOTE_BUILD_DIR_CLEANUP}" == "0" ]] && [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]] && echo "rsync is not supported for preserved builds!"
+# Cleanup under the following conditions:
+# 1) REMOTE_BUILD_DIR_CLEANUP is set to 1.
+# 2) rsync is the supported method of transferring the codebase.
+# 3) git is the supported method but the remote directory either doesn't exist
+#    or is not a git repository, signaling a possible build method switch from
+#    rsync -> git, or the directory was somehow created outside of the agent's
+#    purview.
+# 4) git is the supported method but the remote build directory does not exist yet.
+echo "Cleaning up remote build environment..."
+if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == "1" ]] ||
+	[[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]] ||
+	([[ "${REMOTE_CODEBASE_METHOD}" == "git" ]] && [[ $remote_git_check_result != 0 ]]) ||
+	([[ "${REMOTE_CODEBASE_METHOD}" == "git" ]] && [[ $remote_build_dir_exists_check_result != 0 ]]); then
+	echo "Cleanup is re-initializing the remote environment..."
 	ssh docker-host "(cd ${REMOTE_BUILD_DIR} 2>/dev/null && fin rm -f 2>/dev/null) || true"
 	ssh docker-host "sudo rm -rf ${REMOTE_BUILD_DIR} 2>/dev/null; mkdir -p ${REMOTE_BUILD_DIR}"
 else
-	echo "Cleanup disabled, only applying new changes on remote environment..."
-	# Ensure directory exists. 
-	ssh docker-host "mkdir -p ${REMOTE_BUILD_DIR}"
+	echo "Cleanup is preserving the build environment."
 fi
 
 # Note: build-exec = ssh docker-host "cd $REMOTE_BUILD_DIR && ($@)"
 
-# Remote codebase initialization method. Either 'git' (default) or 'rsync'
+# Remote codebase initialization method. Either 'rsync' (default) or 'git'
 if [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
 	# Rsync sources to the remote host
 	echo "Syncing codebase via rsync..."
@@ -28,10 +42,13 @@ if [[ "${REMOTE_CODEBASE_METHOD}" == "rsync" ]]; then
 else
 	# Checkout sources on the remote host
 	echo "Checking out codebase via git..."
-	if [[ "${REMOTE_BUILD_DIR_CLEANUP}" == "1" ]]; then
-		build-exec "git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la"
+	if [[ $remote_git_check_result == 0 ]] && [[ "${REMOTE_BUILD_DIR_CLEANUP}" == "0" ]]; then
+		# Remote directory is confirmed to be a git repository and we are
+		# preserving the build, so we can safely fetch and reset.
+		build-exec "git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME && ls -la"
 	else
-		build-exec "(git fetch origin && git reset --hard origin/$GIT_BRANCH_NAME && ls -la) || (git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la)"
+		# Remote directory is not a git repository.
+		build-exec "git clone --branch="${GIT_BRANCH_NAME}" --depth 50 ${GIT_REPO_URL} . && git reset --hard ${GIT_COMMIT_HASH} && ls -la"
 	fi
 fi
 
@@ -77,3 +94,5 @@ if [[ "${secrets}" != "" ]]; then
 		build-exec "fin config set $secret='${!secret}' --env=local >/dev/null"
 	done
 fi
+
+set +e


### PR DESCRIPTION
# Changes

New PR based on discussion from #39.

## Summary

This adds functionality for supporting "dirty builds". Dirty builds preserve the build environment and only apply changes to version controlled files and agent-controlled Docksal env variables. Because of the dependency on version control, only Git is supported.

## New Environment Variables

- `REMOTE_BUILD_DIR_CLEANUP`
    - Used in `build-init`, defined in `build-env`.
    - Default value is `1`. This behavior indicates the build environment should be reinitialized during a build. This maintains backwards compatibility.
    - When set to `0`, the build environment is not cleaned up between builds, but preserved and only changes are applied.
    - Is only used in conjunction with a Git build strategy, as being able to know which files have specifically been altered during a build is a requirement, and this information is not available to rsync. If attempting to use with rsync, outputs a message saying preserving builds is not available to rsync and continue to perform a build by reinitializing.

## Additional Changes

- Refactored how configuration is set in docksal-local.env. Rather than tee it up, use `fin config set` as this works identically in both build modes. Because of this, the minimum required version of Docksal would be [1.10.0](https://github.com/docksal/docksal/releases/tag/v1.10.0). This may or may not warrant a major version bump.

# To Do

* [x] Test on Bitbucket Pipelines
* [ ] Test on CircleCI
* [ ] Test on GitLab