### PR TITLE
Allow CI Agent to build against an environment besides local

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Note: on macOS `cat /path/to/<private_key_file> | base64` can be used to create 
 
 ### Optional
 
-`BUILD_AGENT`
+`BUILD_ENVIRONMENT`
 
 Used to set the environment built against. Defaults to `local`.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Note: on macOS `cat /path/to/<private_key_file> | base64` can be used to create 
 
 ### Optional
 
+`BUILD_AGENT`
+
+Used to set the environment built against. Defaults to `local`.
+
 `CI_SSH_KEY`
 
 A base64 encoded private SSH key, used by default for all hosts (set as `Host *` in `~/.ssh/config`).

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -15,6 +15,7 @@ DOCKER_HOST_TUNNEL=localhost:2374
 GIT_USER_EMAIL=${GIT_USER_EMAIL:-ci@docksal.io}
 GIT_USER_NAME=${GIT_USER_NAME:-Docksal CI}
 REMOTE_BUILD_DIR_CLEANUP=${REMOTE_BUILD_DIR_CLEANUP:-1} # Default to re-initializing environment.
+AGENT_ENVIRONMENT=${AGENT_ENVIRONMENT:-local}
 
 # These are used to generate the sandbox sub-domain (branch-project.example.com)
 # There is a limit of 63 characters for any part of the domain name.

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -15,7 +15,6 @@ DOCKER_HOST_TUNNEL=localhost:2374
 GIT_USER_EMAIL=${GIT_USER_EMAIL:-ci@docksal.io}
 GIT_USER_NAME=${GIT_USER_NAME:-Docksal CI}
 REMOTE_BUILD_DIR_CLEANUP=${REMOTE_BUILD_DIR_CLEANUP:-1} # Default to re-initializing environment.
-AGENT_ENVIRONMENT=${AGENT_ENVIRONMENT:-local}
 
 # These are used to generate the sandbox sub-domain (branch-project.example.com)
 # There is a limit of 63 characters for any part of the domain name.

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -59,20 +59,20 @@ fi
 
 # Configure sandbox settings
 echo "Configuring sandbox settings..."
-build-exec "fin config set COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} --env=local"
-build-exec "fin config set VIRTUAL_HOST=${SANDBOX_DOMAIN} --env=local"
+build-exec "fin config set COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} --env=${AGENT_ENVIRONMENT}"
+build-exec "fin config set VIRTUAL_HOST=${SANDBOX_DOMAIN} --env=${AGENT_ENVIRONMENT}"
 
 # Basic HTTP Auth
 if [[ "${HTTP_USER}" != "" ]] && [[ "${HTTP_PASS}" != "" ]]; then
 	echo "Configuring sandbox Basic HTTP Authentication..."
-	build-exec "fin config set APACHE_BASIC_AUTH_USER=${HTTP_USER} --env=local"
-	build-exec "fin config set APACHE_BASIC_AUTH_PASS=${HTTP_PASS} --env=local"
+	build-exec "fin config set APACHE_BASIC_AUTH_USER=${HTTP_USER} --env=${AGENT_ENVIRONMENT}"
+	build-exec "fin config set APACHE_BASIC_AUTH_PASS=${HTTP_PASS} --env=${AGENT_ENVIRONMENT}"
 fi
 
 # Permanent environment switch
 if [[ "${SANDBOX_PERMANENT}" != "" ]]; then
 	echo "Setting sandbox as permanent..."
-	build-exec "fin config set SANDBOX_PERMANENT=${SANDBOX_PERMANENT} --env=local"
+	build-exec "fin config set SANDBOX_PERMANENT=${SANDBOX_PERMANENT} --env=${AGENT_ENVIRONMENT}"
 fi
 
 # Pass CI_SSH_KEY to sandbox
@@ -81,14 +81,14 @@ fi
 # TODO: Load the key into the docksal/ssh-agent service on the sandbox server instead.
 #if [[ "${CI_SSH_KEY}" != "" ]]; then
 #	echo "Passing CI_SSH_KEY to sandbox..."
-#	build-exec "echo SECRET_SSH_PRIVATE_KEY=\"${CI_SSH_KEY}\" | tee -a .docksal/docksal-local.env >/dev/null"
+#	build-exec "echo SECRET_SSH_PRIVATE_KEY=\"${CI_SSH_KEY}\" | tee -a .docksal/docksal-$AGENT_ENVIRONMENT.env >/dev/null"
 #fi
 
 # Pass build secrets to sandbox
 # A "secret" is any environment variable that starts with "SECRET_"
 
 # Parse all environment variables for those prefixed with SECRET_ and then
-# inject each variable/value pair into docksal-local.env. This allows you to
+# inject each variable/value pair into docksal-$AGENT_ENVIRONMENT.env. This allows you to
 # add secure variables to your project's repository that can be injected into
 # each sandbox environment.
 secrets="$(compgen -A variable | grep '^SECRET_')" || true
@@ -96,7 +96,7 @@ if [[ "${secrets}" != "" ]]; then
 	echo "Passing build secrets to sandbox..."
 	for secret in $secrets
 	do
-		build-exec "fin config set $secret='${!secret}' --env=local >/dev/null"
+		build-exec "fin config set $secret='${!secret}' --env=$AGENT_ENVIRONMENT >/dev/null"
 	done
 fi
 

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -3,7 +3,7 @@
 # This script sets up a sandbox environment for the build on the remote docker host.
 
 # Set script-specific variables.
-AGENT_ENVIRONMENT=${AGENT_ENVIRONMENT:-local}
+BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT:-local}
 
 # Exit if using an invalid codebase method.
 if [[ "${REMOTE_CODEBASE_METHOD}" != "rsync" ]] && [[ "${REMOTE_CODEBASE_METHOD}" != "git" ]]; then
@@ -62,20 +62,20 @@ fi
 
 # Configure sandbox settings
 echo "Configuring sandbox settings..."
-build-exec "fin config set COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} --env=${AGENT_ENVIRONMENT}"
-build-exec "fin config set VIRTUAL_HOST=${SANDBOX_DOMAIN} --env=${AGENT_ENVIRONMENT}"
+build-exec "fin config set COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} --env=${BUILD_ENVIRONMENT}"
+build-exec "fin config set VIRTUAL_HOST=${SANDBOX_DOMAIN} --env=${BUILD_ENVIRONMENT}"
 
 # Basic HTTP Auth
 if [[ "${HTTP_USER}" != "" ]] && [[ "${HTTP_PASS}" != "" ]]; then
 	echo "Configuring sandbox Basic HTTP Authentication..."
-	build-exec "fin config set APACHE_BASIC_AUTH_USER=${HTTP_USER} --env=${AGENT_ENVIRONMENT}"
-	build-exec "fin config set APACHE_BASIC_AUTH_PASS=${HTTP_PASS} --env=${AGENT_ENVIRONMENT}"
+	build-exec "fin config set APACHE_BASIC_AUTH_USER=${HTTP_USER} --env=${BUILD_ENVIRONMENT}"
+	build-exec "fin config set APACHE_BASIC_AUTH_PASS=${HTTP_PASS} --env=${BUILD_ENVIRONMENT}"
 fi
 
 # Permanent environment switch
 if [[ "${SANDBOX_PERMANENT}" != "" ]]; then
 	echo "Setting sandbox as permanent..."
-	build-exec "fin config set SANDBOX_PERMANENT=${SANDBOX_PERMANENT} --env=${AGENT_ENVIRONMENT}"
+	build-exec "fin config set SANDBOX_PERMANENT=${SANDBOX_PERMANENT} --env=${BUILD_ENVIRONMENT}"
 fi
 
 # Pass CI_SSH_KEY to sandbox
@@ -84,14 +84,14 @@ fi
 # TODO: Load the key into the docksal/ssh-agent service on the sandbox server instead.
 #if [[ "${CI_SSH_KEY}" != "" ]]; then
 #	echo "Passing CI_SSH_KEY to sandbox..."
-#	build-exec "echo SECRET_SSH_PRIVATE_KEY=\"${CI_SSH_KEY}\" | tee -a .docksal/docksal-$AGENT_ENVIRONMENT.env >/dev/null"
+#	build-exec "echo SECRET_SSH_PRIVATE_KEY=\"${CI_SSH_KEY}\" | tee -a .docksal/docksal-$BUILD_ENVIRONMENT.env >/dev/null"
 #fi
 
 # Pass build secrets to sandbox
 # A "secret" is any environment variable that starts with "SECRET_"
 
 # Parse all environment variables for those prefixed with SECRET_ and then
-# inject each variable/value pair into docksal-$AGENT_ENVIRONMENT.env. This allows you to
+# inject each variable/value pair into docksal-$BUILD_ENVIRONMENT.env. This allows you to
 # add secure variables to your project's repository that can be injected into
 # each sandbox environment.
 secrets="$(compgen -A variable | grep '^SECRET_')" || true
@@ -99,7 +99,7 @@ if [[ "${secrets}" != "" ]]; then
 	echo "Passing build secrets to sandbox..."
 	for secret in $secrets
 	do
-		build-exec "fin config set $secret='${!secret}' --env=${AGENT_ENVIRONMENT} >/dev/null"
+		build-exec "fin config set $secret='${!secret}' --env=${BUILD_ENVIRONMENT} >/dev/null"
 	done
 fi
 

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -2,6 +2,9 @@
 
 # This script sets up a sandbox environment for the build on the remote docker host.
 
+# Set script-specific variables.
+AGENT_ENVIRONMENT=${AGENT_ENVIRONMENT:-local}
+
 # Exit if using an invalid codebase method.
 if [[ "${REMOTE_CODEBASE_METHOD}" != "rsync" ]] && [[ "${REMOTE_CODEBASE_METHOD}" != "git" ]]; then
 	echo "Only rsync and git codebase methods are supported. '${REMOTE_CODEBASE_METHOD}' method given. Aborting."

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -96,7 +96,7 @@ if [[ "${secrets}" != "" ]]; then
 	echo "Passing build secrets to sandbox..."
 	for secret in $secrets
 	do
-		build-exec "fin config set $secret='${!secret}' --env=$AGENT_ENVIRONMENT >/dev/null"
+		build-exec "fin config set $secret='${!secret}' --env=${AGENT_ENVIRONMENT} >/dev/null"
 	done
 fi
 


### PR DESCRIPTION
# Changes

- Adds variable `AGENT_ENVIRONMENT` used in place of the hardcoded local environment in fin commands.