### PR TITLE
Fix loop to iterate over secrets and add short documentation on secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,3 +431,7 @@ REMOTE_BUILD_DIR_CLEANUP=0
 
 Such environments can be used for non-critical production-ish workloads, whenever an on-demand delayed start 
 (5-10s delay) is not a concern.
+
+## Feature: Secrets in environment variables
+
+It is best security practice not to store secrets such as API keys in a code repository. Many CI systems already have the ability to set such environment variables during the build process. Any environment variables set at build time whose name starts with `SECRET_` will be forwarded as-is to the built environment.

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -97,7 +97,7 @@ fi
 secrets="$(compgen -A variable | grep '^SECRET_')" || true
 if [[ "${secrets}" != "" ]]; then
 	echo "Passing build secrets to sandbox..."
-	for secret in "$secrets"
+	for secret in $secrets
 	do
 		build-exec "fin config set $secret='${!secret}' --env=${BUILD_ENVIRONMENT}"
 	done

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -94,13 +94,11 @@ fi
 # inject each variable/value pair into docksal-$BUILD_ENVIRONMENT.env. This allows you to
 # add secure variables to your project's repository that can be injected into
 # each sandbox environment.
-secrets="$(compgen -A variable | grep '^SECRET_')" || true
-if [[ "${secrets}" != "" ]]; then
+if secrets=$(compgen -v | grep '^SECRET_'); then
 	echo "Passing build secrets to sandbox..."
-	for secret in $secrets
-	do
-		build-exec "fin config set $secret='${!secret}' --env=${BUILD_ENVIRONMENT}"
-	done
+	while read secret; do
+		build-exec "fin config set ${secret}='${!secret}' --env=${BUILD_ENVIRONMENT}"
+	done <<< "${secrets}"
 fi
 
 set +e


### PR DESCRIPTION
On our ci build we pass in a few `SECRET_` environment variables. We ended up running into this error when we had more than one such environment variable:

```
 Passing build secrets to sandbox...
/usr/local/bin/build-init: line 102: SECRET_YM_API_KEY
SECRET_YM_SA_PASSCODE: bad substitution
```

That appears to be to do with an erronously-quoted variable in the for loop, which I have fixed in this merge request.

I also added some very quick documentation on the secret environment variable system.