### PR TITLE
Moves REMOTE_BUILD_DIR_CLEANUP to build-init

### DIFF
--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -18,7 +18,6 @@ DEBUG=${DEBUG:-0}  # `DEBUG=1 build-env` to run with debugging turned ON
 DOCKER_HOST_TUNNEL=localhost:2374
 GIT_USER_EMAIL=${GIT_USER_EMAIL:-ci@docksal.io}
 GIT_USER_NAME=${GIT_USER_NAME:-Docksal CI}
-export REMOTE_BUILD_DIR_CLEANUP=${REMOTE_BUILD_DIR_CLEANUP:-1} # Default to re-initializing environment.
 
 # These are used to generate the sandbox sub-domain (branch-project.example.com)
 # There is a limit of 63 characters for any part of the domain name.

--- a/base/bin/build-env
+++ b/base/bin/build-env
@@ -18,7 +18,7 @@ DEBUG=${DEBUG:-0}  # `DEBUG=1 build-env` to run with debugging turned ON
 DOCKER_HOST_TUNNEL=localhost:2374
 GIT_USER_EMAIL=${GIT_USER_EMAIL:-ci@docksal.io}
 GIT_USER_NAME=${GIT_USER_NAME:-Docksal CI}
-REMOTE_BUILD_DIR_CLEANUP=${REMOTE_BUILD_DIR_CLEANUP:-1} # Default to re-initializing environment.
+export REMOTE_BUILD_DIR_CLEANUP=${REMOTE_BUILD_DIR_CLEANUP:-1} # Default to re-initializing environment.
 
 # These are used to generate the sandbox sub-domain (branch-project.example.com)
 # There is a limit of 63 characters for any part of the domain name.

--- a/base/bin/build-init
+++ b/base/bin/build-init
@@ -4,6 +4,7 @@
 
 # Set script-specific variables.
 BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT:-local}
+REMOTE_BUILD_DIR_CLEANUP=${REMOTE_BUILD_DIR_CLEANUP:-1} # Default to re-initializing environment.
 
 # Exit if using an invalid codebase method.
 if [[ "${REMOTE_CODEBASE_METHOD}" != "rsync" ]] && [[ "${REMOTE_CODEBASE_METHOD}" != "git" ]]; then


### PR DESCRIPTION
# Changes

- Need to export `REMOTE_BUILD_DIR_CLEANUP` so when you `source build-env` its available to `build-init`.